### PR TITLE
Python 3 support

### DIFF
--- a/Cryptsy.py
+++ b/Cryptsy.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
 import requests
-import json
 import time
 import hmac,hashlib
 import logging
-import codecs
 
 logging.getLogger("requests").setLevel(logging.NOTSET)
 
@@ -54,7 +51,6 @@ class Cryptsy:
             jsonRet = ret.json()
             return jsonRet
         except ValueError:
-            print(ret.content)
             return {"success": False,
                     "error": {"ValueError": ["Could not load json string."]}}
 


### PR DESCRIPTION
I added a couple of .encode() methods where necessary to get Python 3 to work.  I also used requests to generate the json response instead of the standard json library.  I think this all should still work in Python 2.
